### PR TITLE
[StateMachine] Reuse exeption handling

### DIFF
--- a/src/StateMachine.php
+++ b/src/StateMachine.php
@@ -117,10 +117,6 @@ class StateMachine
 
     public function __call(string $name, array $arguments)
     {
-        if (! $this->findTransition(strtoupper($name))) {
-            throw new TransitionNotDefinedException('Transition not defined');
-        }
-
         $this->transitionTo(strtoupper($name));
     }
 


### PR DESCRIPTION
in case of Transition not defined, transitionTo() will throw TransitionNotDefinedException